### PR TITLE
Feature addition, add noise to mimic

### DIFF
--- a/mlrose/algorithms.py
+++ b/mlrose/algorithms.py
@@ -484,6 +484,9 @@ def mimic(problem, pop_size=200, keep_pct=0.2, max_attempts=10,
     fast_mimic: bool, default: False
         Activate fast mimic mode to compute the mutual information in vectorized form
         Faster speed but requires more memory.
+    noise: float, default: 0
+        Adds noise to the probability and conditional probability estimates.
+        0.01 corresponds to 1% noise.
 
     Returns
     -------

--- a/mlrose/algorithms.py
+++ b/mlrose/algorithms.py
@@ -456,7 +456,7 @@ def genetic_alg(problem, pop_size=200, mutation_prob=0.1, max_attempts=10,
 
 
 def mimic(problem, pop_size=200, keep_pct=0.2, max_attempts=10,
-          max_iters=np.inf, curve=False, random_state=None, fast_mimic=False):
+          max_iters=np.inf, curve=False, random_state=None, fast_mimic=False,noise=0):
     """Use MIMIC to find the optimum for a given optimization problem.
 
     Parameters
@@ -538,6 +538,11 @@ def mimic(problem, pop_size=200, keep_pct=0.2, max_attempts=10,
         raise Exception("""fast_mimic mode must be a boolean.""")
     else:
         problem.mimic_speed=fast_mimic
+
+    if (noise < 0) or (noise > 0.1):
+        raise Exception("""noise must be between 0 and 0.1.""")
+    else:
+        problem.noise=noise
 
     # Initialize problem, population and attempts counter
     problem.reset()

--- a/mlrose/opt_probs.py
+++ b/mlrose/opt_probs.py
@@ -364,9 +364,23 @@ class DiscreteOpt(OptProb):
                 if not len(subset):
                     probs[i, j] = 1/self.max_val
                 else:
-                    probs[i, j] = np.histogram(subset[:, i],
+
+                    temp_probs = np.histogram(subset[:, i],
                                                np.arange(self.max_val + 1),
                                                density=True)[0]
+
+                    #Check if noise argument is not default (in epsilon)
+                    if self.noise!=0:
+                        #Add noise, from the mimic argument "noise"
+                        temp_probs = (temp_probs + self.noise)
+                        #All probability adds up to one
+                        temp_probs=np.divide(temp_probs,np.sum(temp_probs))
+                        #Handle floating point error to ensure probability adds up to 1
+                        if sum(temp_probs) != 1.0:
+                            temp_probs = np.divide(temp_probs, np.sum(temp_probs))
+                        #Set probability
+
+                    probs[i, j]=temp_probs
 
         # Update probs and parent
         self.node_probs = probs

--- a/mlrose/opt_probs.py
+++ b/mlrose/opt_probs.py
@@ -272,6 +272,7 @@ class DiscreteOpt(OptProb):
         self.sample_order = []
         self.prob_type = 'discrete'
         self.mimic_speed = False
+        self.noise=0
 
     def eval_node_probs(self):
         """Update probability density estimates.


### PR DESCRIPTION
This feature lets users add noise to mimic.

Users can add an optional "noise" argument to set the noise between 0.00 ~ 0.10, which corresponds to 0 to 10% noise. (Which gets renormalized). The default is set to 0.

0.01 corresponds to adding 1% probability to all probabilities and conditional probabilities to the features and then renormalizing them.

Adopted from 4.3 Refining Samples Generated by MIMIC in Randomized Local Search as Successive Estimation of Probability Densities by Charles L. Isbell, Jr.
