### PR TITLE
Avoid deprecation warning from sklearn.externals.six

### DIFF
--- a/mlrose/neural.py
+++ b/mlrose/neural.py
@@ -7,9 +7,9 @@ from abc import ABCMeta
 from abc import abstractmethod
 
 import numpy as np
+import six
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.metrics import mean_squared_error, log_loss
-from sklearn.externals import six
 from .activation import identity, relu, sigmoid, softmax, tanh
 from .algorithms import random_hill_climb, simulated_annealing, genetic_alg
 from .opt_probs import ContinuousOpt

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(name='mlrose',
           "Topic :: Software Development :: Libraries",
           "Topic :: Software Development :: Libraries :: Python Modules"],
       packages=['mlrose'],
-      install_requires=['numpy', 'scipy', 'sklearn'],
+      install_requires=['numpy', 'six', 'scikit-learn', 'scipy'],
       python_requires='>=3',
       zip_safe=False)


### PR DESCRIPTION
The changes here should avoid the deprecation warnings from sklearn about its internal six module being deprecated in favor of the "official" six module: 
```
$ python -c "import mlrose"
/Users/ksb/opt/anaconda3/envs/ccsi-foqus/lib/python3.7/site-packages/sklearn/externals/six.py:31: FutureWarning: The module is deprecated in version 0.21 and will be removed in version 0.23 since we've dropped support for Python 2.7. Please rely on the official version of six (https://pypi.org/project/six/).
  "(https://pypi.org/project/six/).", FutureWarning)
```
I also changed the name used to identify scikit-learn as a requirement to (what I understand to be) the more correct name `scikit-learn` which avoids the "alias" package `sklearn-0.0` from getting installed.

All the tests run by `./test/test.sh` still pass with this change, so hopefully this is correct.  If not, hopefully this is a hint in the direction on how to avoid the deprecation warning.
