### PR TITLE
Remove sklearn.externals.six usage, enable GridSearchCV and bump version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Genevieve Hayes'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.3.0'
+release = '1.4.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 
 setup(name='mlrose',
-      version='1.3.0',
+      version='1.4.0',
       description="MLROSe: Machine Learning, Randomized Optimization and"
       + " Search",
       long_description=readme(),


### PR DESCRIPTION
- Python Environment

```yaml
# conda env create --file mlrose.environment.yml
name: mlrose
dependencies:
- python=3.8
- pip=20.2.3
- pip:
    - mlrose==1.3.0
```

- Test Code

```python
#!/usr/bin/env python3
# -*- coding: utf-8 -*-

import mlrose

from sklearn.datasets import load_iris
from sklearn.metrics import accuracy_score
from sklearn.model_selection import train_test_split
from sklearn.preprocessing import MinMaxScaler, OneHotEncoder
from sklearn.model_selection import GridSearchCV


def main():
    # Load the Iris dataset
    data = load_iris()

    # Split data into training and test sets
    X_train, X_test, y_train, y_test = train_test_split(
        data.data, data.target, test_size=0.2, random_state=3)

    # Normalize feature data
    scaler = MinMaxScaler()
    X_train_scaled = scaler.fit_transform(X_train)
    X_test_scaled = scaler.transform(X_test)

    # One hot encode target values
    encoder = OneHotEncoder()
    y_train_hot = encoder.fit_transform(y_train.reshape(-1, 1)).todense()
    y_test_hot = encoder.transform(y_test.reshape(-1, 1)).todense()

    # Initialize neural network object
    model = mlrose.NeuralNetwork(hidden_nodes=[2], activation='relu',
                                 algorithm='random_hill_climb', max_iters=1000,
                                 bias=True, is_classifier=True, learning_rate=0.0001,
                                 early_stopping=True, clip_max=5, max_attempts=100,
                                 random_state=3)

    #  Fit object
    model.fit(X_train_scaled, y_train_hot)

    # Predict labels for train set and assess accuracy
    y_train_pred = model.predict(X_train_scaled)
    y_train_accuracy = accuracy_score(y_train_hot, y_train_pred)
    print('y_train_accuracy: {}'.format(y_train_accuracy))

    # Predict labels for test set and assess accuracy
    y_test_pred = model.predict(X_test_scaled)
    y_test_accuracy = accuracy_score(y_test_hot, y_test_pred)
    print('y_test_accuracy: {}'.format(y_test_accuracy))

    param_grid = {
        'max_iters': [100, 500],
    }
    gscv = GridSearchCV(model, param_grid=param_grid, cv=5)
    gscv.fit(X_train_scaled, y_train_hot)


if __name__ == '__main__':
    main()
```

- Error messages for errors that are now fixed

```bash
# sklearn.externals.six
Traceback (most recent call last):
  File "./main.py", line 5, in <module>
    import mlrose
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/mlrose/__init__.py", line 12, in <module>
    from .neural import NeuralNetwork, LinearRegression, LogisticRegression
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/mlrose/neural.py", line 12, in <module>
    from sklearn.externals import six
ImportError: cannot import name 'six' from 'sklearn.externals' (/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/externals/__init__.py)
```

```bash
# GridSearchCV
/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/model_selection/_validation.py:548: FitFailedWarning: Estimator fit failed. The score on this train-test partition for these parameters will be set to nan. Details: 
Traceback (most recent call last):
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/model_selection/_validation.py", line 531, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
AttributeError: 'NoneType' object has no attribute 'fit'

  warnings.warn("Estimator fit failed. The score on this train-test"
Traceback (most recent call last):
  File "./main.py", line 59, in <module>
    main()
  File "./main.py", line 55, in main
    gscv.fit(X_train_scaled, y_train_hot)
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/utils/validation.py", line 72, in inner_f
    return f(**kwargs)
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/model_selection/_search.py", line 761, in fit
    self.best_estimator_ = clone(clone(base_estimator).set_params(
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/utils/validation.py", line 72, in inner_f
    return f(**kwargs)
  File "/home/obe/anaconda3/envs/mlrose/lib/python3.8/site-packages/sklearn/base.py", line 78, in clone
    raise TypeError("Cannot clone object '%s' (type %s): "
TypeError: Cannot clone object 'None' (type <class 'NoneType'>): it does not seem to be a scikit-learn estimator as it does not implement a 'get_params' method.
```