### PR TITLE
fix six importerror

### DIFF
--- a/mlrose/neural.py
+++ b/mlrose/neural.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.metrics import mean_squared_error, log_loss
-from sklearn.externals import six
+import six
 from .activation import identity, relu, sigmoid, softmax, tanh
 from .algorithms import random_hill_climb, simulated_annealing, genetic_alg
 from .opt_probs import ContinuousOpt

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(name='mlrose',
           "Topic :: Software Development :: Libraries",
           "Topic :: Software Development :: Libraries :: Python Modules"],
       packages=['mlrose'],
-      install_requires=['numpy', 'scipy', 'sklearn'],
+      install_requires=['numpy', 'scipy', 'sklearn', 'six'],
       python_requires='>=3',
       zip_safe=False)


### PR DESCRIPTION
Attempting to fix #59 and #52. To my knowledge, it should be this simple. You can test the installation by running

`pip install git+https://github.com/pcjedi/mlrose@master`

After that, mlrose can be imported without error/workaround.