### PR TITLE
dependencies: sklearn -> scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(name='mlrose',
           "Topic :: Software Development :: Libraries",
           "Topic :: Software Development :: Libraries :: Python Modules"],
       packages=['mlrose'],
-      install_requires=['numpy', 'scipy', 'sklearn'],
+      install_requires=['numpy', 'scipy', 'scikit-learn'],
       python_requires='>=3',
       zip_safe=False)


### PR DESCRIPTION
declaring `sklearn` as a dependency is going to be deprecated https://github.com/scikit-learn/sklearn-pypi-package