### PR TITLE
Replace sklearn.externals.six with six

### DIFF
--- a/mlrose/neural.py
+++ b/mlrose/neural.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.metrics import mean_squared_error, log_loss
-from sklearn.externals import six
+import six
 from .activation import identity, relu, sigmoid, softmax, tanh
 from .algorithms import random_hill_climb, simulated_annealing, genetic_alg
 from .opt_probs import ContinuousOpt

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(name='mlrose',
           "Topic :: Software Development :: Libraries",
           "Topic :: Software Development :: Libraries :: Python Modules"],
       packages=['mlrose'],
-      install_requires=['numpy', 'scipy', 'scikit-learn'],
+      install_requires=['six', 'numpy', 'scipy', 'scikit-learn'],
       python_requires='>=3',
       zip_safe=False)


### PR DESCRIPTION
After the recent move from sklearn to scikit-learn (via PR #65), it became necessary to import six directly.

@gkhayes @ChristopherBilg May I request you to please consider?